### PR TITLE
Nexus InitialHotWalletAmount should be in DFM when registering

### DIFF
--- a/e2e-polybft/cardanofw/test-evm-chain.go
+++ b/e2e-polybft/cardanofw/test-evm-chain.go
@@ -37,7 +37,7 @@ type TestEVMChainConfig struct {
 	IsEnabled bool
 
 	ValidatorCount         int
-	InitialHotWalletAmount *big.Int
+	InitialHotWalletAmount *big.Int // in wei
 	FundAmount             *big.Int
 	FundRelayerAmount      *big.Int
 	PreminesAddresses      []types.Address
@@ -230,7 +230,8 @@ func (ec *TestEVMChain) InitContracts(bridgeAdmin *crypto.ECDSAKey, bridgeURL st
 }
 
 func (ec *TestEVMChain) RegisterChain(validator *TestApexValidator) error {
-	return validator.RegisterChain(ec.config.ChainID, ec.config.InitialHotWalletAmount, ChainTypeEVM)
+	return validator.RegisterChain(
+		ec.config.ChainID, WeiToDfm(ec.config.InitialHotWalletAmount), ChainTypeEVM)
 }
 
 func (ec *TestEVMChain) GetGenerateConfigsParams(indx int) (result []string) {


### PR DESCRIPTION
# Description

when registering nexus chain, initialHotWalletAmount is in wei, but bridge sc expects dfm

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [ ] I have added the relevant labels
- [ ] I have updated the official documentation
- [ ] I have added sufficient documentation in code

## Testing

- [ ] I have tested this code with the official test suite
- [ ] I have tested this code manually

### Manual tests

Please complete this section if you ran manual tests for this functionality, otherwise delete it

# Documentation update

Please link the documentation update PR in this section if it's present, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
